### PR TITLE
Display Fat & Protein on Apple Watch

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		38FEF3FE2738083E00574A46 /* CGMProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FEF3FD2738083E00574A46 /* CGMProvider.swift */; };
 		38FEF408273B011A00574A46 /* LibreTransmitterSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FEF407273B011A00574A46 /* LibreTransmitterSource.swift */; };
 		38FEF413273B317A00574A46 /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FEF412273B317A00574A46 /* HKUnit.swift */; };
+		3FDF90922A51E0AA009B2B77 /* NutrientsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FDF90912A51E0AA009B2B77 /* NutrientsView.swift */; };
 		44190F0BBA464D74B857D1FB /* PreferencesEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A965332F237348B119FB858 /* PreferencesEditorRootView.swift */; };
 		448B6FCB252BD4796E2960C0 /* PumpSettingsEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0274EE6439B1C3ED70730D41 /* PumpSettingsEditorDataFlow.swift */; };
 		45252C95D220E796FDB3B022 /* ConfigEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */; };
@@ -766,6 +767,7 @@
 		3BF768BD6264FF7D71D66767 /* NightscoutConfigProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NightscoutConfigProvider.swift; sourceTree = "<group>"; };
 		3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PumpConfigStateModel.swift; sourceTree = "<group>"; };
 		3F8A87AA037BD079BA3528BA /* ConfigEditorDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorDataFlow.swift; sourceTree = "<group>"; };
+		3FDF90912A51E0AA009B2B77 /* NutrientsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NutrientsView.swift; sourceTree = "<group>"; };
 		42369F66CF91F30624C0B3A6 /* BasalProfileEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BasalProfileEditorProvider.swift; sourceTree = "<group>"; };
 		44080E4709E3AE4B73054563 /* ConfigEditorProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorProvider.swift; sourceTree = "<group>"; };
 		47DFCE895C930F784EF11843 /* CalibrationsStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalibrationsStateModel.swift; sourceTree = "<group>"; };
@@ -1770,6 +1772,7 @@
 				38E8757A2757B1C300975559 /* TempTargetsView.swift */,
 				38E8757C2757C45D00975559 /* BolusView.swift */,
 				38E8757F27595DC500975559 /* BolusConfirmationView.swift */,
+				3FDF90912A51E0AA009B2B77 /* NutrientsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2803,6 +2806,7 @@
 				38E8757927579D9200975559 /* Publisher.swift in Sources */,
 				38E8755B27568A6800975559 /* ConfirmationView.swift in Sources */,
 				38E8757D2757C45D00975559 /* BolusView.swift in Sources */,
+				3FDF90922A51E0AA009B2B77 /* NutrientsView.swift in Sources */,
 				38E8752E27554D5700975559 /* NotificationController.swift in Sources */,
 				38E8754C2755548F00975559 /* WatchStateModel.swift in Sources */,
 				38E8754A275550BB00975559 /* CarbsView.swift in Sources */,

--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -37,6 +37,7 @@
       "insulinReqPercentage" : 80,
       "useFPUconversion" : false,
       "displayOnWatch" : "HR",
+      "isNutrientsViewEnabled" : false,
       "animatedBackground" : false
       "maxCarbs": 1000
 }

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -31,6 +31,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var useAppleHealth: Bool = false
     var smoothGlucose: Bool = false
     var displayOnWatch: AwConfig = .BGTarget
+    var isNutrientsViewEnabled: Bool = false
     var overrideHbA1cUnit: Bool = false
     var high: Decimal = 145
     var low: Decimal = 70
@@ -97,6 +98,10 @@ extension FreeAPSSettings: Decodable {
 
         if let displayOnWatch = try? container.decode(AwConfig.self, forKey: .displayOnWatch) {
             settings.displayOnWatch = displayOnWatch
+        }
+
+        if let isNutrientsViewEnabled = try? container.decode(Bool.self, forKey: .isNutrientsViewEnabled) {
+            settings.isNutrientsViewEnabled = isNutrientsViewEnabled
         }
 
         if let cgm = try? container.decode(CGMType.self, forKey: .cgm) {

--- a/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
@@ -35,10 +35,10 @@ extension AddCarbs {
 
             if useFPUconversion {
                 // -------------------------- FPU--------------------------------------
-                let interval = settings.settings.minuteInterval // Interval betwwen carbs
+                let interval = settings.settings.minuteInterval // Interval between carbs
                 let timeCap = settings.settings.timeCap // Max Duration
                 let adjustment = settings.settings.individualAdjustmentFactor
-                let delay = settings.settings.delay // Tme before first future carb entry
+                let delay = settings.settings.delay // Time before first future carb entry
 
                 let kcal = protein * 4 + fat * 9
                 let carbEquivalents = (kcal / 10) * adjustment
@@ -93,7 +93,7 @@ extension AddCarbs {
                 if carbEquivalents > 0 {
                     carbsStorage.storeCarbs(futureCarbArray)
                 }
-            } // ------------------------- END OF TPU ----------------------------------------
+            } // ------------------------- END OF FPU ----------------------------------------
 
             // Store the real carbs
             if carbs > 0 {

--- a/FreeAPS/Sources/Modules/WatchConfig/View/WatchConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/WatchConfig/View/WatchConfigRootView.swift
@@ -17,6 +17,7 @@ extension WatchConfig {
                             Text(v.displayName).tag(v)
                         }
                     }
+                    Toggle("Display Fat & Protein", isOn: $state.isNutrientsViewEnabled)
                 }
                 Section(header: Text("Garmin Watch")) {
                     List {

--- a/FreeAPS/Sources/Modules/WatchConfig/WatchConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/WatchConfig/WatchConfigStateModel.swift
@@ -30,6 +30,7 @@ extension WatchConfig {
         @Injected() private var garmin: GarminManager!
         @Published var devices: [IQDevice] = []
         @Published var selectedAwConfig: AwConfig = .HR
+        @Published var isNutrientsViewEnabled = false
 
         private(set) var preferences = Preferences()
 
@@ -45,6 +46,10 @@ extension WatchConfig {
                 default:
                     self?.settingsManager.settings.displayHR = false
                 }
+            }
+
+            subscribeSetting(\.isNutrientsViewEnabled, on: $isNutrientsViewEnabled) {
+                self.settingsManager.settings.isNutrientsViewEnabled = $0
             }
 
             devices = garmin.devices

--- a/FreeAPSWatch WatchKit Extension/DataFlow.swift
+++ b/FreeAPSWatch WatchKit Extension/DataFlow.swift
@@ -21,6 +21,7 @@ struct WatchState: Codable {
     var eventualBG: String?
     var eventualBGRaw: String?
     var displayOnWatch: AwConfig?
+    var isNutrientsViewEnabled: Bool?
     var isf: Decimal?
     var override: String?
 }

--- a/FreeAPSWatch WatchKit Extension/Views/MainView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/MainView.swift
@@ -251,8 +251,11 @@ struct MainView: View {
     var buttons: some View {
         HStack(alignment: .center) {
             NavigationLink(isActive: $state.isCarbsViewActive) {
-                CarbsView()
-                    .environmentObject(state)
+                if state.isNutrientsViewEnabled {
+                    NutrientsView().environmentObject(state)
+                } else {
+                    CarbsView().environmentObject(state)
+                }
             } label: {
                 Image("carbs", bundle: nil)
                     .renderingMode(.template)

--- a/FreeAPSWatch WatchKit Extension/Views/NutrientsView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/NutrientsView.swift
@@ -1,0 +1,192 @@
+import SwiftUI
+
+struct Constants {
+    static let pickerHSpacing: CGFloat = 4
+    static let defaultPickerStep = 5
+}
+
+struct NutrientsView: View {
+    @EnvironmentObject var watchStateModel: WatchStateModel
+
+    @State var carbCount = 0
+    @State var fatCount = 0
+    @State var proteinCount = 0
+
+    let defaultMaxCOB = 120
+    var maxCOB: Int {
+        if let unwrappedMaxCOB = watchStateModel.maxCOB {
+            return Int(unwrappedMaxCOB)
+        }
+        return defaultMaxCOB
+    }
+
+    // Safety max Protein & max Fat cap set to double of maxCOB
+    // For reference:
+    // 500g of Chicken Breast contains around 155g of Protein
+    // 500g of Bacon contains around 210g of Fat
+    var defaultMaxProtein: Int { maxCOB * 2 }
+    var defaultMaxFat: Int { maxCOB * 2 }
+
+    var isSubmitButtonDisabled: Bool {
+        carbCount <= 0 && fatCount <= 0 && proteinCount <= 0
+    }
+
+    var body: some View {
+        VStack {
+            HStack(spacing: Constants.pickerHSpacing) {
+                GramsPicker(
+                    selection: $carbCount,
+                    label: "Carbs",
+                    labelAlignment: .leading,
+                    max: maxCOB,
+                    accentColor: .white
+                )
+
+                GramsPicker(
+                    selection: $proteinCount,
+                    label: "Protein",
+                    labelAlignment: .center,
+                    max: defaultMaxProtein,
+                    accentColor: .red
+                )
+
+                GramsPicker(
+                    selection: $fatCount,
+                    label: "Fat",
+                    labelAlignment: .trailing,
+                    max: defaultMaxFat,
+                    accentColor: .orange
+                )
+            }
+            .padding(.bottom, 24)
+            HStack {
+                Button {
+                    WKInterfaceDevice.current().play(.click)
+                    watchStateModel.isCarbsViewActive = false
+                } label: {
+                    Text("Cancel")
+                }
+                Button {
+                    WKInterfaceDevice.current().play(.click)
+                    watchStateModel.addNutrients([
+                        .carb: carbCount,
+                        .protein: proteinCount,
+                        .fat: fatCount
+                    ])
+                } label: {
+                    Text("Add").opacity(isSubmitButtonDisabled ? 0.4 : 1)
+                }
+                .tint(.loopYellow)
+                .disabled(isSubmitButtonDisabled)
+            }
+            .padding([.leading, .trailing], 4)
+            .padding(.bottom, 12)
+        }
+        .frame(maxHeight: .infinity)
+        .edgesIgnoringSafeArea(.bottom)
+        .navigationTitle("Nutrients")
+        .onAppear {
+            if let unwrappedCarbsRequired = watchStateModel.carbsRequired {
+                carbCount = Int(unwrappedCarbsRequired)
+            }
+        }
+    }
+
+    struct GramsPicker: View {
+        @Environment(\.sizeCategory) var sizeCategory
+        @State var step = Constants.defaultPickerStep
+        let labelFrameWidth = WKInterfaceDevice.current().screenBounds.width - 8
+
+        @Binding var selection: Int
+        let label: String
+        let labelAlignment: Alignment
+        let max: Int
+        let accentColor: Color
+
+        var fontForSizeCategory: Font {
+            switch sizeCategory {
+            case .extraSmall,
+                 .small:
+                return .system(size: 12)
+            case .medium:
+                return .system(size: 14)
+            case .large:
+                return .system(size: 16)
+            default:
+                return .system(size: 20)
+            }
+        }
+
+        var fontForSizeCategoryForHundreds: Font {
+            switch sizeCategory {
+            case .extraSmall:
+                return .system(size: 8)
+            case .small:
+                return .system(size: 9)
+            case .large,
+                 .medium:
+                return .system(size: 14)
+            default:
+                return .system(size: 16)
+            }
+        }
+
+        var body: some View {
+            GeometryReader { geometry in
+                Picker(selection: $selection) {
+                    ForEach(0 ... (max / step), id: \.self) {
+                        let value = $0 * step
+                        Text("\(value) g")
+                            .tag(value)
+                            .font(value < 99 ? fontForSizeCategory : fontForSizeCategoryForHundreds)
+                            .foregroundColor(accentColor)
+                    }
+                } label: {
+                    var labelFrameTranslationX: CGFloat {
+                        let offset = geometry.size.width + Constants.pickerHSpacing
+                        if labelAlignment == .leading { return offset }
+                        if labelAlignment == .trailing { return -offset }
+                        return 0
+                    }
+                    Text(label)
+                        .foregroundColor(.black)
+                        .padding(.vertical, 2)
+                        .padding(.horizontal, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(accentColor)
+                        )
+                        .textCase(.uppercase)
+                        .frame(width: labelFrameWidth, alignment: labelAlignment)
+                        .transformEffect(.init(translationX: labelFrameTranslationX, y: 0))
+                }
+                .pickerStyle(.wheel)
+                .frame(maxWidth: geometry.size.width)
+                .onTapGesture(count: 2, perform: handlePickerDoubleTapGesture)
+            }
+        }
+
+        private func handlePickerDoubleTapGesture() {
+            step = step == Constants.defaultPickerStep ? 1 : Constants.defaultPickerStep
+            if step == Constants.defaultPickerStep {
+                selection = Int(Double(selection / Constants.defaultPickerStep).rounded(.down)) * Constants
+                    .defaultPickerStep
+            }
+        }
+    }
+}
+
+struct NutrientsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let watchStateModel = WatchStateModel()
+        watchStateModel.carbsRequired = 110
+
+        return Group {
+            NutrientsView()
+            NutrientsView()
+                .previewDevice("Apple Watch Series 5 - 40mm")
+            NutrientsView()
+                .previewDevice("Apple Watch Series 3 - 38mm")
+        }.environmentObject(watchStateModel)
+    }
+}


### PR DESCRIPTION
Added `Nutrients` screen where a user can log `Carbs`, `Protein`, and `Fat` from Apple Watch.

### To Fix
- [ ] Add text localization (via `NSLocalizedString` ?)
- [ ] Create `NutrientsModel` which can store and serialize/deserialize Nutrients data.
- [ ] Add `NutritionView` tests
- [ ] Use `carbs` instead of `carb`
- [ ] Add an option to change `Protein` <-> `Fat` order

### Notes
- The new screen is disabled by default
- Picker step can be toggled between `5` and `1` via double tap for more precise numbers.

|iPhone|Apple Watch
|-|-
|![Screenshot 2023-07-05 at 15 00 57](https://github.com/Artificial-Pancreas/iAPS/assets/17122466/a123ac90-28e8-4188-ad3b-57d5255e5c3f)|<img width="356" alt="Screenshot 2023-07-05 at 01 15 11" src="https://github.com/Artificial-Pancreas/iAPS/assets/17122466/e79d37c6-d82c-4b05-80a8-e8606d205383">
